### PR TITLE
fix: Some bracket rules are fallbacked to the generic one

### DIFF
--- a/builtin_rules/c.vim
+++ b/builtin_rules/c.vim
@@ -2,7 +2,9 @@ let s:stack = gyoza#config#get_rules_for_filetype(expand('<sfile>:t:r'))
 
 function s:add_brace_rule() abort
   call s:stack.add_rule('\v^\s*%(%(typedef\s+)?%(struct|enum)|class)>.*\{$',
-    \ '};', ['\=^}', '\=^\%(protected\|private\|public\)\s*:'])
+    \ {-> {'pair': '};', 'skip': 'rest'}},
+    \ ['\=^}', '\=^\%(protected\|private\|public\)\s*:'])
   call s:stack.add_rule('\v^\s*switch\s*\(.*\)\s*\{$',
-    \ '}', ['\=^\%(case\s*.*:\|default:\)'])
+    \ {-> {'pair': '}', 'skip': 'rest'}},
+    \ ['\=^\%(case\s*.*:\|default:\)'])
 endfunction

--- a/builtin_rules/go.vim
+++ b/builtin_rules/go.vim
@@ -6,7 +6,9 @@ endfunction
 
 function s:add_brace_rule() abort
   call s:stack.add_rule(
-    \ '\v^\s*%(select>|switch\s*\S*\s*)\s*\{$', '}', ['\=^\%(case\s*.*:\|default:\)'])
+    \ '\v^\s*%(select>|switch\s*\S*\s*)\s*\{$',
+    \ {_ -> {'pair': '}', 'skip': 'rest'}},
+    \ ['\=^\%(case\s*.*:\|default:\)'])
   call s:stack.add_rule(
     \ '\v^\s*%(defer|go)\s+func\s*\([^)]{-}\)\s*\{$', '}()', ['\=^}\s*('])
 endfunction


### PR DESCRIPTION
Previously, some language-specific bracket rules are fallbacked into the generic one when they are canceled due to the match between their cancelers and next line text:

```cpp
class A {|
private:
};
```

↓ Type `<CR>` at the position of `|`

```cpp
class A {
}
private:
};
```

This PR prohibits the fallback and fixes it.