### PR TITLE
fix: Error when the pair text has special characters

### DIFF
--- a/autoload/gyoza/applier.vim
+++ b/autoload/gyoza/applier.vim
@@ -101,7 +101,8 @@ function s:do_apply() abort
     endif
   endif
 
-  execute 'inoremap <buffer> <Plug>(_gyoza_do_input)' s:current_rule.pair
+  execute 'inoremap <buffer> <Plug>(_gyoza_do_input)'
+    \ s:escape_text_for_mapping(s:current_rule.pair)
 
   " I don't know why but the last input character will be disappared without
   " <Ignore> between these two mappings.

--- a/test/applier.vimspec
+++ b/test/applier.vimspec
@@ -491,6 +491,16 @@ Describe Applier class
       \.run()
   End
 
+  It works well even when there're "|" and key notation in the pair text.
+    let rules = NewConfig().add_rule('^', {_ -> {'pair': '|xxx<Tab>'}})._rules
+    call cursor(1, 1)
+    call NewScripter()
+      \.feedkeys('a<CR>')
+      \.call({-> gyoza#applier#trigger_applicant(rules)})
+      \.call({-> s:assert.equals(GetAllLines(), ['', '', '|xxx<Tab>'])})
+      \.run()
+  End
+
   It does not collapse cursor text when it contains special character like "<Tab>".
     let rules = NewConfig().add_rule('^\s*if\>', 'endif')._rules
     call setline(1, 'if<Tab>')


### PR DESCRIPTION
Fix errors when the pair text contains special characters/strings like "|" or Vim script key notations (e.g. \<Tab>).

### Rough reproduce steps

- Launch vim and load vim-gyoza plugin.
- `:call setline(1, '{}|xxx')`
- Type `gg^a<CR>`
- Error is raised:
  ```
  Error detected while processing function <SNR>110_do_apply:
  line   55:
  E492: Not an editor command: xxx
  ```
